### PR TITLE
Fix confusion in desktop file

### DIFF
--- a/AdobeReader.desktop
+++ b/AdobeReader.desktop
@@ -6,6 +6,6 @@ Type=Application
 GenericName=PDF Viewer
 Terminal=false
 Icon=com.adobe.Reader
-X-KDE-StartupNotify=false
+StartupNotify=false
 Categories=Office;Viewer;
 InitialPreference=9


### PR DESCRIPTION
The X-KDE- prefix in desktop file confuses flathub which put the app under KDE group in the store where it clearly doesn't belong.